### PR TITLE
feat(classes): add method to retrieve students from a class

### DIFF
--- a/front/src/services/ClassesService.ts
+++ b/front/src/services/ClassesService.ts
@@ -108,6 +108,32 @@ export const ClassesService = {
     });
     return response.data.data || response.data;
   },
+
+  // Buscar alunos de uma turma
+  getClassStudents: async (id: number): Promise<ClassStudent[]> => {
+    try {
+      const response = await api.get(`api/turmas/${id}`, {
+        headers: getAuthHeaders(),
+        withCredentials: true
+      });
+      
+      const classData = response.data.data || response.data;
+      const alunos = classData.alunos || [];
+      
+      // Mapear os dados da API para o formato esperado pelo componente
+      return alunos.map((aluno: any) => ({
+        id: aluno.id,
+        classId: classData.id,
+        studentId: aluno.id,
+        studentName: aluno.name,
+        studentEmail: aluno.email,
+        enrolledAt: aluno.created_at || new Date().toISOString()
+      }));
+    } catch (error) {
+      handleAuthError(error);
+      throw error;
+    }
+  },
 };
 
 export default ClassesService;


### PR DESCRIPTION
This pull request adds a new method to the `ClassesService` for fetching students enrolled in a specific class. The method retrieves the class data from the API, extracts the student list, and maps it to the format expected by frontend components.

New API method for class students:

* Added `getClassStudents` method to `ClassesService` in `front/src/services/ClassesService.ts`, which fetches students for a given class and maps the API response to the `ClassStudent` format.