### PR TITLE
fix: corrige erro ao listar turmas para usuários admin

### DIFF
--- a/back/src/app/Http/Controllers/TurmaController.php
+++ b/back/src/app/Http/Controllers/TurmaController.php
@@ -25,9 +25,11 @@ class TurmaController extends Controller
             return TurmaResource::collection($user->professor->turmas)->response();
         } elseif ($user->aluno) {
             return TurmaResource::collection($user->aluno->turmas)->response();
+        } elseif ($user->hasRole('admin')) {
+            return TurmaResource::collection(Turma::all())->response();
         }
 
-        return TurmaResource::collection(Turma::all())->response();
+        return response()->json('Acesso não autorizado.', 403);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Corrige o bug descrito na issue #53
- O método `index()` do `TurmaController` assumia que todo usuário não-professor era aluno, causando `Attempt to read property "turmas" on null` ao logar como admin
- Adiciona verificação explícita do role `admin` com `hasRole('admin')`
- Retorna `403` para usuários sem perfil válido, corrigindo falha de segurança

## Mudanças
- `back/src/app/Http/Controllers/TurmaController.php`: lógica do `index()` agora verifica explicitamente professor, aluno e admin

## Test plan
- [x] Logar como admin (`admin@admin.com`) e acessar a listagem de turmas → vê todas
- [x] Logar como professor → vê apenas suas turmas
- [x] Logar como aluno → vê apenas suas turmas
- [ ] Usuário sem perfil válido → recebe 403

Closes #53