### PR TITLE
fix: invalida sessão web e regenera CSRF token no logout

### DIFF
--- a/back/src/app/Http/Controllers/Auth/AuthController.php
+++ b/back/src/app/Http/Controllers/Auth/AuthController.php
@@ -28,6 +28,10 @@ class AuthController extends Controller
     {
         $request->user()->tokens()->delete();
 
+        Auth::guard('web')->logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
         return response()->noContent();
     }
 


### PR DESCRIPTION
## Summary

- Corrige bug onde o logout não invalidava a sessão web, causando falha no primeiro login ao trocar de usuário
- Adiciona `Auth::guard('web')->logout()`, `session()->invalidate()` e `session()->regenerateToken()` no método `logout()` do `AuthController`

## Problema

Após logout, a sessão do servidor permanecia autenticada com o usuário anterior. Ao tentar logar com outro usuário, o primeiro login falhava e só funcionava na segunda tentativa.

## Test plan

- [ ] Fazer login com usuário A
- [ ] Fazer logout
- [ ] Fazer login com usuário B
- [ ] Verificar que o login funciona na primeira tentativa
- [ ] Repetir o processo com diferentes combinações de usuários

Closes #56