### PR TITLE
fix: corrige status pendente em submissão do ProblemaSeeder

### DIFF
--- a/back/src/database/seeders/ProblemaSeeder.php
+++ b/back/src/database/seeders/ProblemaSeeder.php
@@ -200,7 +200,7 @@ class ProblemaSeeder extends Seeder
             ]);
         }
 
-        // Bruno - submissão pendente na atividade 3
+        // Bruno - submissão aceita na atividade 3
         if ($bruno && $a3) {
             Submissao::create([
                 'data_submissao' => now(),
@@ -208,7 +208,7 @@ class ProblemaSeeder extends Seeder
                 'linguagem' => 50, // C
                 'atividade_id' => $a3->id,
                 'user_id' => $bruno->id,
-                'status_correcao_id' => 1, // Na Fila
+                'status_correcao_id' => 3, // Aceita
             ]);
         }
 


### PR DESCRIPTION
## Summary

- Corrige submissão do Bruno no `ProblemaSeeder` que usava `status_correcao_id = 1` (Na Fila) sem possuir tokens do Judge0
- Altera o status para `3` (Aceita), evitando que o sistema tente consultar o Judge0 com tokens vazios

## Problema

O `SubmissaoController::index()` chama `getStatus()` para cada submissão, que consulta o Judge0 via HTTP. Submissões do seeder não possuem correções com tokens, então o Judge0 retorna HTTP 400. Como o `php artisan serve` é single-threaded, essas chamadas síncronas travavam o servidor, bloqueando login e outras requisições.

## Test plan

- [ ] Rodar `php artisan migrate:fresh --seed`
- [ ] Logar como aluno (`ana.carolina@email.com` / `password123`)
- [ ] Acessar a lista de submissões
- [ ] Verificar que o servidor não trava e nenhum erro 400 aparece nos logs

Closes #58