### PR TITLE
fix: adiciona CSRF token no POST de submissão de código

### DIFF
--- a/front/src/services/SubmissionsService.ts
+++ b/front/src/services/SubmissionsService.ts
@@ -26,6 +26,7 @@ export async function getSubmissionById(
 }
 import { fakeSubmissions } from "../mocks";
 import axios from "axios";
+import Cookies from "js-cookie";
 
 const API_URL = (import.meta as any).env?.VITE_API_URL || "http://localhost:8000";
 
@@ -125,6 +126,10 @@ export async function postSubmission({
   activityId: number;
 }): Promise<Submission | undefined> {
   try {
+    await axios.get(`${API_URL}/sanctum/csrf-cookie`, {
+      withCredentials: true,
+    });
+
     const response = await axios.post(`${API_URL}/api/submissoes`, {
       codigo: code,
       atividade_id: activityId,
@@ -133,6 +138,7 @@ export async function postSubmission({
         Authorization: `Bearer ${localStorage.getItem("auth_token")}`,
         "Content-Type": "application/json",
         Accept: "application/json",
+        "X-XSRF-TOKEN": Cookies.get("XSRF-TOKEN"),
       },
       withCredentials: true,
     });


### PR DESCRIPTION
## Summary

- Corrige erro 419 (CSRF token mismatch) ao submeter código
- Adiciona busca do CSRF cookie (`GET /sanctum/csrf-cookie`) antes do POST
- Inclui o header `X-XSRF-TOKEN` na request de submissão

## Problema

A função `postSubmission` no `SubmissionsService.ts` enviava `withCredentials: true` mas não incluía o `X-XSRF-TOKEN`. Como o Sanctum aplica verificação CSRF para domínios stateful, toda submissão falhava com erro 419. Nenhum usuário conseguia submeter código pelo frontend.

## Test plan

- [ ] Logar como aluno (`ana.carolina@email.com` / `password123`)
- [ ] Acessar uma atividade com prazo aberto
- [ ] Submeter código
- [ ] Verificar que a submissão é criada sem erro 419

Closes #60