### PR TITLE
fix: submissão otimista sem redirect e correção do spinner repetitivo

### DIFF
--- a/back/src/app/Http/Controllers/SubmissaoController.php
+++ b/back/src/app/Http/Controllers/SubmissaoController.php
@@ -47,20 +47,9 @@ class SubmissaoController extends Controller
         $submissoesFormatted = collect($submissoes)->map(function (Submissao $submissao) {
             $dados = $submissao->toArray();
 
-            // Usa o getStatus() que já busca corretamente do Judge0
-            try {
-                $statusData = $submissao->getStatus();
-
-                $dados['status'] = $statusData['status'] ?? null;
-                $dados['status_descricao'] = $statusData['status'] ?? null;
-            } catch (Exception $e) {
-                \Log::error("Erro ao buscar status da submissão {$submissao->id}: " . $e->getMessage());
-
-                // Fallback para o status da submissão
-                $statusInfo = Status::get((int) $submissao->status_correcao_id) ?? null;
-                $dados['status'] = $statusInfo['nome'] ?? null;
-                $dados['status_descricao'] = $statusInfo['descricao'] ?? null;
-            }
+            $statusInfo = Status::get((int) ($submissao->status_correcao_id ?? Status::NA_FILA));
+            $dados['status'] = $statusInfo['nome'] ?? null;
+            $dados['status_descricao'] = $statusInfo['descricao'] ?? null;
 
             // Adiciona informações do problema
             if ($submissao->atividade && $submissao->atividade->problema) {
@@ -188,20 +177,9 @@ class SubmissaoController extends Controller
         $submissoesFormatted = collect($submissoes->items())->map(function (Submissao $submissao) {
             $dados = $submissao->toArray();
 
-            // Usa o getStatus() que já busca corretamente do Judge0
-            try {
-                $statusData = $submissao->getStatus();
-
-                $dados['status'] = $statusData['status'] ?? null;
-                $dados['status_descricao'] = $statusData['status'] ?? null;
-            } catch (Exception $e) {
-                \Log::error("Erro ao buscar status da submissão {$submissao->id}: " . $e->getMessage());
-
-                // Fallback para o status da submissão
-                $statusInfo = Status::get((int) $submissao->status_correcao_id) ?? null;
-                $dados['status'] = $statusInfo['nome'] ?? null;
-                $dados['status_descricao'] = $statusInfo['descricao'] ?? null;
-            }
+            $statusInfo = Status::get((int) ($submissao->status_correcao_id ?? Status::NA_FILA));
+            $dados['status'] = $statusInfo['nome'] ?? null;
+            $dados['status_descricao'] = $statusInfo['descricao'] ?? null;
 
             unset($dados['status_correcao_id']);
             unset($dados['correcoes']);

--- a/front/src/context/DataContext.tsx
+++ b/front/src/context/DataContext.tsx
@@ -4,6 +4,8 @@ import React, {
   useContext,
   useState,
   useEffect,
+  useRef,
+  useCallback,
   useMemo,
 } from "react";
 import type { Activity, Problem, Submission } from "@/types";
@@ -57,23 +59,23 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({
     );
   }, [submissions]);
 
-  const updateSubmissions = async () => {
+  const updateSubmissions = useCallback(async () => {
     try {
       const submissions = await getAllSubmissions();
       setSubmissions(submissions);
     } catch (error) {
       console.error("DataContext: Erro ao atualizar submissões:", error);
     }
-  };
+  }, []);
 
-  const updateActivities = async () => {
+  const updateActivities = useCallback(async () => {
     try {
       const activitiesData = await getAllActivities();
       setActivities(activitiesData.items);
     } catch (error) {
       console.error("DataContext: Erro ao atualizar atividades:", error);
     }
-  };
+  }, []);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -111,42 +113,44 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [user, userLoading]);
 
   // Polling para atualizar submissões pendentes/processando a cada 10 segundos
+  const hasPendingSubmissions = useRef(false);
   useEffect(() => {
-    const hasPendingSubmissions = submissions.some(
+    hasPendingSubmissions.current = submissions.some(
       (s) => s.status === "pending" || s.status === "processing"
     );
-
-    if (!hasPendingSubmissions) {
-      return;
-    }
-
-    const intervalId = setInterval(async () => {
-      await updateSubmissions();
-    }, 10000);
-
-    return () => {
-      clearInterval(intervalId);
-    };
   }, [submissions]);
 
-  // Polling para atualizar atividades pendentes a cada 10 segundos
   useEffect(() => {
-    const hasPendingActivities = activities.some(
-      (a: Activity) => a.status === "pending"
-    );
-
-    if (!hasPendingActivities) {
-      return;
-    }
-
     const intervalId = setInterval(async () => {
-      await updateActivities();
+      if (hasPendingSubmissions.current) {
+        await updateSubmissions();
+      }
     }, 10000);
 
     return () => {
       clearInterval(intervalId);
     };
+  }, [updateSubmissions]);
+
+  // Polling para atualizar atividades pendentes a cada 10 segundos
+  const hasPendingActivities = useRef(false);
+  useEffect(() => {
+    hasPendingActivities.current = activities.some(
+      (a: Activity) => a.status === "pending"
+    );
   }, [activities]);
+
+  useEffect(() => {
+    const intervalId = setInterval(async () => {
+      if (hasPendingActivities.current) {
+        await updateActivities();
+      }
+    }, 10000);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [updateActivities]);
 
   return (
     <DataContext.Provider

--- a/front/src/pages/activitiesDetails/ActivitiesDetails.tsx
+++ b/front/src/pages/activitiesDetails/ActivitiesDetails.tsx
@@ -165,6 +165,7 @@ export default function ActivitiesDetails() {
     mapProblems,
     loading,
     updateSubmissions,
+    submissions,
   } = useData();
 
   const [activitySubmissions, setActivitySubmissions] = useState<Submission[]>([]);
@@ -214,7 +215,19 @@ export default function ActivitiesDetails() {
     if (selectedActivity) {
       fetchSubmissions(selectedActivity);
     }
-  }, [selectedActivity]);
+  }, [selectedActivity?.id]);
+
+  // Sincroniza a lista local quando o polling global atualiza submissions
+  useEffect(() => {
+    const hasPending = activitySubmissions.some(
+      (s) => s.status === "pending" || s.status === "processing"
+    );
+    if (hasPending && selectedActivity) {
+      getSubmissionsByActivityId(String(selectedActivity.id)).then((data) => {
+        setActivitySubmissions(data);
+      });
+    }
+  }, [submissions]);
 
   // Redireciona para o detalhe da submissão ao clicar na linha da tabela
   function redirectToSubmission(submission: Submission) {
@@ -223,22 +236,29 @@ export default function ActivitiesDetails() {
 
   async function handleSubmit(code: string, activityId: number) {
     try {
-      setLocalLoading(true);
-      await postSubmission({
+      const response = await postSubmission({
         code: code,
         activityId: activityId,
       });
-      await updateSubmissions();
-      // refresh local activity submissions as well
-      if (selectedActivity) {
-        await fetchSubmissions(selectedActivity);
-      }
-      navigate(`/submissions`);
+
+      // Optimistic update: add new submission with "pending" status immediately
+      // postSubmission returns raw backend data (Portuguese field names)
+      const raw = response as any;
+      const newSubmission: Submission = {
+        id: raw?.id ?? Date.now(),
+        activityId: raw?.atividade_id ?? activityId,
+        dateSubmitted: raw?.data_submissao ?? new Date().toISOString(),
+        language: raw?.linguagem ?? "c",
+        status: "pending",
+      };
+
+      setActivitySubmissions((prev) => [newSubmission, ...prev]);
+
+      // Fire-and-forget: update global submissions in background
+      updateSubmissions();
     } catch (error) {
       alert("Erro ao submeter o código. Tente novamente.");
       console.error("Error submitting code:", error);
-    } finally {
-      setLocalLoading(false);
     }
   }
 

--- a/front/src/pages/submissionsDetails/SubmissionsDetails.tsx
+++ b/front/src/pages/submissionsDetails/SubmissionsDetails.tsx
@@ -376,21 +376,11 @@ export default function SubmissionsDetails() {
 
       setLoading(true);
       try {
-        const submissionResultCall = getResultBySubmissionId(
+        const submissionResult = await getResultBySubmissionId(
           Number(submissionId)
         );
 
-        const [submissionResult] = await Promise.all([submissionResultCall]);
-
         setResults(submissionResult);
-
-        // Se o problema não estiver no cache e temos a atividade, busca diretamente
-        if (selectedActivity && !mapProblems.get(selectedActivity.problemId)) {
-          const problem = await getProblemById(String(selectedActivity.problemId));
-          if (problem) {
-            setFetchedProblem(problem);
-          }
-        }
       } catch (error) {
         console.error("Failed to fetch submission details:", error);
       } finally {
@@ -398,7 +388,18 @@ export default function SubmissionsDetails() {
       }
     };
     fetchData();
-  }, [submissionId, selectedActivity, mapProblems]);
+  }, [submissionId]);
+
+  // Busca o problema separadamente quando a atividade estiver disponível
+  useEffect(() => {
+    if (selectedActivity && !mapProblems.get(selectedActivity.problemId)) {
+      getProblemById(String(selectedActivity.problemId)).then((problem) => {
+        if (problem) {
+          setFetchedProblem(problem);
+        }
+      });
+    }
+  }, [selectedActivity?.problemId]);
 
   if (loading) {
     return (


### PR DESCRIPTION
Closes #62

## Summary

- Submissão de código agora usa **optimistic update** — aparece instantaneamente com status "Pendente"
- Remove o **redirect para /submissions** — aluno permanece na página da atividade
- Corrige **spinner aparecendo a cada ~10s** no histórico de submissões
- Refatora **polling do DataContext** para estabilidade
- Separa **fetch do problema** do fetch de resultados em SubmissionsDetails
- **Usa `status_correcao_id` do banco** nos endpoints de listagem em vez de chamar Judge0 por submissão, eliminando N chamadas HTTP externas

## Mudança no backend — Status via banco

Os endpoints `GET /api/submissoes` (index) e `GET /api/submissoes/atividades/{id}` (getSubmissionByUser) chamavam `$submissao->getStatus()` para **cada submissão**, que fazia uma requisição HTTP ao Judge0. Com 50 submissões, eram ~10-15s de espera.

O `CheckSubmissionStatusJob` já atualiza `status_correcao_id` no banco de forma assíncrona. Agora os endpoints de listagem leem direto do banco (~50ms), usando `Status::get()` para traduzir o ID em nome/descrição.

O endpoint `GET /api/submissoes/{id}` (show) continua chamando Judge0 para status real-time ao visualizar uma submissão individual.

## Mudanças no frontend

### `ActivitiesDetails.tsx` — `handleSubmit()`
1. `await postSubmission()` → envia o código
2. Mapeia resposta para `Submission` com `status: "pending"` → aparece **instantaneamente**
3. `updateSubmissions()` sem `await` → atualiza global em background
4. **Sem redirect, sem spinner bloqueante**

### `ActivitiesDetails.tsx` — `useEffect([selectedActivity?.id])`
- Dependência trocada para valor primitivo (ID) em vez de referência do objeto
- Só dispara quando o aluno navega para **outra atividade**, não a cada polling

### `DataContext.tsx` — Polling estável
- `updateSubmissions` e `updateActivities` envolvidos com `useCallback`
- Flags de pending/processing em `useRef` para evitar reinício dos intervalos

### `SubmissionsDetails.tsx` — Fetch separado
- Fetch do problema separado do fetch de resultados em `useEffect` independente

## Arquivos modificados

| Arquivo | Mudança |
|---------|---------|
| `back/.../SubmissaoController.php` | Usa `status_correcao_id` do DB em vez de Judge0 nos endpoints de listagem |
| `front/.../ActivitiesDetails.tsx` | Optimistic update, remove redirect/spinner, sync via polling |
| `front/.../DataContext.tsx` | useCallback + useRef no polling |
| `front/.../SubmissionsDetails.tsx` | Separa fetch do problema |

## Test plan

- [ ] Submeter código → submissão aparece instantaneamente com status "Pendente"
- [ ] Verificar que NÃO redireciona para /submissions
- [ ] Aguardar ~10-20s → status atualiza automaticamente (ex: "Aceita" ou "Erro")
- [ ] Verificar que o histórico NÃO mostra spinner durante polling
- [ ] `GET /api/submissoes` responde em < 1s (sem chamadas ao Judge0)
- [ ] Navegar para outra atividade → carrega normalmente
- [ ] Acessar detalhes de uma submissão → carrega corretamente (este endpoint ainda usa Judge0)