### PR TITLE
fix: exibe data e hora nas submissões para diferenciar tentativas

### DIFF
--- a/back/src/app/Models/Submissao.php
+++ b/back/src/app/Models/Submissao.php
@@ -36,6 +36,10 @@ class Submissao extends Model
         'status_correcao_id'
     ];
 
+    protected $casts = [
+        'data_submissao' => 'datetime',
+    ];
+
     public function atividade(): BelongsTo
     {
         return $this->belongsTo(Atividade::class);

--- a/back/src/database/migrations/2026_02_23_120000_change_data_submissao_to_timestamp.php
+++ b/back/src/database/migrations/2026_02_23_120000_change_data_submissao_to_timestamp.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('submissao', function (Blueprint $table) {
+            $table->timestamp('data_submissao')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('submissao', function (Blueprint $table) {
+            $table->date('data_submissao')->nullable()->change();
+        });
+    }
+};

--- a/front/src/pages/activitiesDetails/ActivitiesDetails.tsx
+++ b/front/src/pages/activitiesDetails/ActivitiesDetails.tsx
@@ -126,6 +126,8 @@ function formatDate(dateString: string) {
     day: "2-digit",
     month: "2-digit",
     year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
   });
 
   let relative = "";

--- a/front/src/pages/submissions/Submissions.tsx
+++ b/front/src/pages/submissions/Submissions.tsx
@@ -368,13 +368,14 @@ export default function Submissions() {
             </TableHeader>
             <TableBody>
               {sortedSubmissions.map((submission) => {
-                // mostra apenas a data (sem horário) na tabela principal
                 const formattedDateOnly = new Date(
                   submission.dateSubmitted
                 ).toLocaleDateString("pt-BR", {
                   day: "2-digit",
                   month: "2-digit",
                   year: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
                 });
                 
                 // Usa o título do problema que vem do backend

--- a/front/src/pages/submissionsDetails/SubmissionsDetails.tsx
+++ b/front/src/pages/submissionsDetails/SubmissionsDetails.tsx
@@ -430,13 +430,14 @@ export default function SubmissionsDetails() {
   }
 
   const dueDate = formatDate(selectedActivity.dueDate);
-  // mostra apenas a data (sem horário) no cartão de detalhes
   const formattedSubmissionDateOnly = new Date(
     submission.dateSubmitted
   ).toLocaleDateString("pt-BR", {
     day: "2-digit",
     month: "2-digit",
     year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
   });
 
   return (


### PR DESCRIPTION
Closes #64

## Problema

A coluna `data_submissao` no banco de dados era do tipo `date`, armazenando apenas a data (ex: `2026-02-23`) sem horário. No frontend, o timestamp era formatado sem hora/minuto. Resultado: quando um aluno faz múltiplas submissões no mesmo dia, todas apareciam com a mesma informação (ex: `23/02/2026`), impossibilitando diferenciar uma tentativa da outra.

## Solução

### Backend
- **Migration** — Altera a coluna `data_submissao` de `date` para `timestamp`, permitindo armazenar hora/minuto/segundo
- **Model `Submissao`** — Adiciona `$casts` com `'data_submissao' => 'datetime'` para serialização correta

### Frontend
Adiciona `hour: "2-digit"` e `minute: "2-digit"` ao formato de data em todas as telas que exibem timestamp de submissão:

- **Lista de Submissões** (`Submissions.tsx`) — tabela principal
- **Detalhes da Atividade** (`ActivitiesDetails.tsx`) — histórico de submissões dentro da atividade
- **Detalhes da Submissão** (`SubmissionsDetails.tsx`) — cartão de informações

O formato passa de `23/02/2026` para `23/02/2026 14:35`.

## Arquivos modificados

| Arquivo | Mudança |
|---------|---------|
| `back/src/database/migrations/2026_02_23_120000_change_data_submissao_to_timestamp.php` | Altera coluna de `date` para `timestamp` |
| `back/src/app/Models/Submissao.php` | Adiciona `$casts` para `data_submissao => datetime` |
| `front/src/pages/submissions/Submissions.tsx` | Adiciona hora e minuto ao formato de data |
| `front/src/pages/activitiesDetails/ActivitiesDetails.tsx` | Adiciona hora e minuto no `formatDate()` |
| `front/src/pages/submissionsDetails/SubmissionsDetails.tsx` | Adiciona hora e minuto ao formato de data |

## Test plan

- [ ] Rodar `php artisan migrate` para aplicar a migration
- [ ] Submeter código duas vezes — timestamps devem ter horários diferentes
- [ ] Acessar `/submissions` — data deve exibir dia/mês/ano e hora:minuto
- [ ] Acessar detalhes de uma atividade — histórico deve exibir data com hora
- [ ] Acessar detalhes de uma submissão — cartão deve exibir data com hora