### PR TITLE
fix: corrige judge0 crashando em loop no Windows (CRLF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF line endings for files mounted into Linux containers
+*.conf text eol=lf
+*.sh   text eol=lf

--- a/judge0.conf
+++ b/judge0.conf
@@ -192,7 +192,7 @@ REDIS_HOST=judge0_redis
 
 # Specify Redis port.
 # Default: 6379
-REDIS_PORT=
+REDIS_PORT=6379
 
 # Specify Redis password. Cannot be blank.
 # Default: NO DEFAULT! MUST BE SET!


### PR DESCRIPTION
## Summary

Closes #66

- Adiciona `.gitattributes` forçando `eol=lf` em `*.conf` e `*.sh`, prevenindo que o Git no Windows converta line endings para CRLF em arquivos montados dentro de containers Linux
- Define `REDIS_PORT=6379` explicitamente no `judge0.conf` (vazio era interpretado como porta 0, causando `SocketError`)

## Contexto

No Windows, o Git converte line endings para CRLF por padrão. O `judge0.conf` é montado via volume no container Linux, que lê `INTERVAL=2\r` — o `\r` quebra o comando `seq` do entrypoint e o server crasha em loop. Os workers tentam reconectar infinitamente, consumindo **63% de CPU**.

## Antes → Depois

| Métrica | Antes | Depois |
|---------|-------|--------|
| `judge0_server` | Restart loop (`Restarting (0)`) | Rodando normalmente (Puma listening :2358) |
| `judge0_workers` CPU | **63.7%** | **1.28%** |
| Redis connection | `Error connecting on judge0_redis:0` | Conectado na porta 6379 |

## Test plan

- [ ] Clonar em máquina Windows, rodar `docker compose up`
- [ ] Verificar que `judge0_server` e `judge0_workers` ficam `Up` sem restart
- [ ] Verificar que submissões de código são processadas normalmente
- [ ] Confirmar que em Linux/Mac continua funcionando sem alteração